### PR TITLE
fix Adapting to changes in YouTube's specifications.

### DIFF
--- a/youtube-live-stream-chat-url-updater.lua
+++ b/youtube-live-stream-chat-url-updater.lua
@@ -14,16 +14,89 @@ g_source_name9 = ""
 function get_video_id()
   local handle = io.popen("curl -s "..g_channel_url)
   local stdout = handle:read("*a")
-  result = string.match(stdout, "\"videoRenderer\":{\"videoId\":\"[^\"]+\"")
-  if result == nil then
-    result = string.match(stdout, "\"gridVideoRenderer\":{\"videoId\":\"[^\"]+\"")
+
+  local yt_initial_data = string.match(stdout, "ytInitialData.*$")
+  -- Split text. ","&"{" .
+  local lines = {}
+  for s in string.gmatch(stdout, "[^,{]+") do
+    lines[#lines+1] = s
   end
-  if result ~= nil then
-    result = string.match(result, ":\"[^\"]+\"")
-    result = string.gsub(result, ":", "")
-    result = string.gsub(result, "\"", "")
+
+  -- text seach mode.
+  local SEARCH_THUMBNAIL_BADGE_VIEW_MODEL = 0
+  local SEARCH_DURATION_TEXT              = 1
+  local SEARCH_METADATA_PARTS             = 2
+  local SEARCH_DATE                       = 3
+  local SEARCH_VIDEO_ID                   = 4
+
+  -- Search data.
+  local mode = SEARCH_THUMBNAIL_BADGE_VIEW_MODEL
+  local video_id = nil
+  local upcoming_date = "9999/99/99 99:99"
+
+  for i, v in ipairs(lines) do
+    if mode == SEARCH_THUMBNAIL_BADGE_VIEW_MODEL then
+      local str = string.match(v, "\"thumbnailBadgeViewModel\":")
+      if str then
+        mode = SEARCH_DURATION_TEXT
+      end
+
+    elseif mode == SEARCH_DURATION_TEXT then
+      local str = string.match(v, "\"text\":\"[^:0-9]+\"") -- 長さなし == 配信予定 or ライブ.
+      if str then
+        mode = SEARCH_METADATA_PARTS
+      else
+        str = string.match(v, "\"delimiter\"") -- 要素の終端判定.
+        if str then
+          mode = SEARCH_THUMBNAIL_BADGE_VIEW_MODEL
+        end
+      end
+
+    elseif mode == SEARCH_METADATA_PARTS then
+      local str = string.match(v, "\"metadataParts\"")
+      if str then
+        mode = SEARCH_DATE
+      end
+
+    elseif mode == SEARCH_DATE then
+      local date = nil
+      local time = nil
+      str = string.match(v, "\"delimiter\"") -- 要素の終端判定.
+      if str then -- No Date == Now Live
+        date = "0000/00/00"
+        time = "00:00"
+      else
+        date, time = string.match(v, "\"content\":\"(%d%d%d%d/%d%d/%d%d) (%d+:%d%d)")
+      end
+
+      if date then
+        if string.len(time) == 4 then
+          time = "0" .. time
+        end
+        str = date .. " " .. time
+        if upcoming_date > str then
+          upcoming_date = str
+          mode = SEARCH_VIDEO_ID
+        else
+          mode = SEARCH_THUMBNAIL_BADGE_VIEW_MODEL
+        end
+      end
+
+    elseif mode == SEARCH_VIDEO_ID then
+      local str = string.match(v, "\"contentId\":\"[^\"]+\"")
+      if str then
+        -- Get video id
+        str = string.match(str, ":\"[^\"]+\"")
+        str = string.gsub(str, ":", "")
+        str = string.gsub(str, "\"", "")
+        video_id = str
+        mode = SEARCH_THUMBNAIL_BADGE_VIEW_MODEL
+      end
+
+    end
   end
-  return result
+
+  return video_id
 end
 
 function confirm_curl()
@@ -41,7 +114,7 @@ function update_live_url()
     print("Error: Channel URL is not set.")
     return
   end
-  
+
   video_id = get_video_id()
   if video_id == nil then
     if confirm_curl() then
@@ -51,7 +124,7 @@ function update_live_url()
   end
   print(g_channel_url)
   print(video_id)
-  
+
   source_name_list = {
     g_source_name1,
     g_source_name2,
@@ -63,7 +136,7 @@ function update_live_url()
     g_source_name8,
     g_source_name9
   }
-  
+
   for i = 1, #source_name_list do
     source_name = source_name_list[i]
     if source_name ~= "" then
@@ -76,7 +149,7 @@ function update_live_url()
       end
     end
   end
-  
+
 end
 
 function button(props, p)
@@ -100,7 +173,7 @@ end
 
 function script_properties()
   local props = obs.obs_properties_create()
-  obs.obs_properties_add_text(props, "channel_url", "Channel URL", obs.OBS_TEXT_DEFAULT)
+  obs.obs_properties_add_text(props, "channel_url", "Channel [Live] Tab URL", obs.OBS_TEXT_DEFAULT)
   obs.obs_properties_add_text(props, "source_name1", "Source name1", obs.OBS_TEXT_DEFAULT)
   obs.obs_properties_add_text(props, "source_name2", "Source name2", obs.OBS_TEXT_DEFAULT)
   obs.obs_properties_add_text(props, "source_name3", "Source name3", obs.OBS_TEXT_DEFAULT)


### PR DESCRIPTION
YouTubeのチャンネルページを構成するオブジェクトの名称が変わり、VideoIDが取得できなくなっていたので修正を行いました。
また、今までは最初に見つかった要素のVideoIDを取得していましたが、配信中 or 直近の配信予定のVideoIDを取得するように改修しました。